### PR TITLE
Adding Helper Scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,15 @@
   "version": "0.0.0",
   "author": "Michael Herman <michael@mherman.org> (http://mherman.org)",
   "license": "ISC",
+  "scripts": {
+    "start": "node node_modules/gulp/bin/gulp.js",
+    "postinstall": "npm run bower-install&&npm run driver-install",
+    "bower-install": "node node_modules/bower/bin/bower install",
+    "driver-install": "node node_modules/.bin/webdriver-manager update --standalone",
+    "driver": "node node_modules/.bin/webdriver-manager start",
+    "unit": "node node_modules/gulp/bin/gulp.js unit",
+    "e2e": "node node_modules/gulp/bin/gulp.js e2e"
+  },
   "dependencies": {},
   "devDependencies": {
     "chai": "2.2.0",


### PR DESCRIPTION
Lots of steps during install/running that I felt were confusing.
Hence, helper scripts.

To Install:
- `npm install` now runs NPM module installation as usual, as well as Bower installation and Selenium driver update installation.

To Run:
- `npm run driver` starts the Selenium driver (do in tab 1)
- `npm start` starts the HTTP server for our static Angular asset files (do in tab 2)
- `npm run unit` runs unit tests (do in tab 3)
- `npm run e2e` runs e2e tests (do in tab 3)
